### PR TITLE
Configure RSpec to run with autotest properly

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--format documentation

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in balanced.gemspec
 gemspec
+
+gem 'rspec'

--- a/lib/balanced/base.rb
+++ b/lib/balanced/base.rb
@@ -30,7 +30,7 @@ module Balanced
           # here is where our interpretations will begin.
           # if the value is a sub-resource, lets instantiate the class
           # and set it correctly
-          if value.instance_of? Hash and value.has_key? 'uri'
+          if value.instance_of? Hash and value.has_key? :uri
             value = construct_from_response value
           elsif name =~ /_uri$/
             modified_name = name.sub(/_uri$/, '')

--- a/spec/account_spec.rb
+++ b/spec/account_spec.rb
@@ -1,0 +1,4 @@
+require "spec_helper"
+
+describe Balanced::Account do
+end

--- a/spec/api_key_spec.rb
+++ b/spec/api_key_spec.rb
@@ -2,19 +2,46 @@ require "spec_helper"
 
 describe "ApiKey Resource" do
   before(:each) do
+    Balanced.stub(:send) { 
+      mock(
+        Faraday::Response, 
+        body: 
+          {
+            merchant: {
+              phone_number: "+16505551212", 
+              city: "Nowhere", 
+              marketplace: nil, 
+              name: "William Henry Cavendish III", 
+              email_address: "whc@example.org", 
+              created_at: "2012-06-08T01:51:36.489382Z", 
+              uri: "/v1/merchants/TEST-merchant_id", 
+              accounts_uri: "/v1/merchants/TEST-merchant_id/accounts", 
+              meta: {}, 
+              postal_code: "90210", 
+              country_code: "USA", 
+              type: "person", 
+              balance: 0, 
+              api_keys_uri: "/v1/merchants/TEST-merchant_id/api_keys", 
+              id: "TEST-merchant_id", 
+              street_address: "123 Fake St"
+            },
+            secret: "some-secret", 
+            meta: {},
+            uri: "/v1/api_keys/api-key",
+            id: "api-key"
+          }
+      )
+    }
   end
 
   it "should create my api key and let me access the secret" do
     key = Balanced::ApiKey.new.save
-    key.should_not eq(nil)
     # make sure my secret is there.
-    key.secret.should_not eq(nil)
+    key.secret.should == "some-secret"
   end
 
   it "should construct the merchant sub resource as an instance of Balanced::Merchant" do
     key = Balanced::ApiKey.new.save
     (key.merchant.instance_of? Balanced::Merchant).should == true
   end
-
-
 end

--- a/spec/api_key_spec.rb
+++ b/spec/api_key_spec.rb
@@ -1,4 +1,4 @@
-require "balanced"
+require "spec_helper"
 
 describe "ApiKey Resource" do
   before(:each) do

--- a/spec/balanced_spec.rb
+++ b/spec/balanced_spec.rb
@@ -1,4 +1,4 @@
-require "balanced"
+require "spec_helper"
 
 describe "Balanced module" do
   before(:each) do

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,4 +1,4 @@
-require "balanced"
+require "spec_helper"
 
 describe "balanced client" do
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,7 @@
+require 'rubygems'
+require 'bundler/setup'
+
+require 'balanced'
+
+RSpec.configure do |config|
+end

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -1,4 +1,4 @@
-require "balanced"
+require "spec_helper"
 
 describe "the utils module" do
   it "should correctly translate underscored names" do


### PR DESCRIPTION
Test suite was not running with autotest. With the fixes, autotest now runs properly and executes all specs appropriately.

`spec/api_key_spec.rb` was tightly coupled with the http request logic. We've removed this coupling by mocking `Faraday::Response` and returning the expected hash.

The rest is self-explanatory from the commit messages.
