### PR TITLE
Hold#void fix

### DIFF
--- a/lib/balanced/resources/hold.rb
+++ b/lib/balanced/resources/hold.rb
@@ -24,7 +24,7 @@ module Balanced
     # Cancels an active Hold.
     #
     def void
-      @is_void = true
+      self.is_void = true
       save
     end
 

--- a/spec/balanced/resources/hold_spec.rb
+++ b/spec/balanced/resources/hold_spec.rb
@@ -1,0 +1,39 @@
+require "spec_helper"
+
+describe Balanced::Hold do
+  use_vcr_cassette
+  before do
+    api_key = Balanced::ApiKey.new.save
+    Balanced.configure api_key.secret
+    @marketplace = Balanced::Marketplace.new.save
+    card = Balanced::Card.new(
+      :card_number      => "5105105105105100",
+      :expiration_month => "12",
+      :expiration_year  => "2015"
+    ).save
+    @buyer = @marketplace.create_buyer("buyer@example.org", card.uri)
+  end
+
+  describe "#void" do
+    use_vcr_cassette
+
+    before do
+      @hold = @buyer.hold 100
+    end
+
+    describe 'before' do
+      use_vcr_cassette
+      subject { @hold.is_void }
+      it { should be_false }
+    end
+
+    describe 'after' do
+      use_vcr_cassette
+      before { @hold.void }
+
+      subject { @hold.is_void }
+      it { should be_true }
+    end  
+
+  end
+end


### PR DESCRIPTION
Hold#void doesn't actually void the hold. Instance variable @is_void is used instead of @attributes[:is_void].
