### PR TITLE
fixes #31: support Kaminari-style pagination parameters

### DIFF
--- a/lib/balanced/pager.rb
+++ b/lib/balanced/pager.rb
@@ -154,12 +154,12 @@ module Balanced
     end
 
     def adjust_pagination_params(original)
-      params = original.dup
-      per = original.delete(:per)
-      params[:limit] = per unless per.nil?
-      page = original.delete(:page)
-      params[:offset] = (params[:limit] || DEFAULT_LIMIT) * ([page, 1].max - 1) unless page.nil?
-      params
+      adjusted = original.dup
+      per = adjusted.delete(:per)
+      adjusted[:limit] = per unless per.nil?
+      page = adjusted.delete(:page)
+      adjusted[:offset] = (adjusted[:limit] || DEFAULT_LIMIT) * ([page, 1].max - 1) unless page.nil?
+      adjusted
     end
 
     # Stolen from Mongrel, with some small modifications:

--- a/lib/balanced/pager.rb
+++ b/lib/balanced/pager.rb
@@ -156,9 +156,9 @@ module Balanced
     def adjust_pagination_params(original)
       params = original.dup
       per = original.delete(:per)
-      params[:limit] = per if per.present?
+      params[:limit] = per unless per.nil?
       page = original.delete(:page)
-      params[:offset] = (params[:limit] || DEFAULT_LIMIT) * ([page, 1].max - 1) if page.present?
+      params[:offset] = (params[:limit] || DEFAULT_LIMIT) * ([page, 1].max - 1) unless page.nil?
       params
     end
 

--- a/spec/balanced/pager_spec.rb
+++ b/spec/balanced/pager_spec.rb
@@ -1,0 +1,42 @@
+require "spec_helper"
+
+describe Balanced::Pager do
+  describe "#adjust_pagination_params" do
+    subject { Balanced::Pager.new 'a uri'}
+
+    it "sets limit based on per" do
+      params = subject.send(:adjust_pagination_params, per: 5)
+      params[:limit].should == 5
+    end
+
+    it "sets offset based on page and default limit" do
+      params = subject.send(:adjust_pagination_params, page: 2)
+      params[:offset].should == 10
+    end
+
+    it "sets offset based on page and per" do
+      params = subject.send(:adjust_pagination_params, page: 2, per: 4)
+      params[:offset].should == 4
+    end
+
+    it "prefers per to limit" do
+      params = subject.send(:adjust_pagination_params, per: 5, limit: 10)
+      params[:limit].should == 5
+    end
+
+    it "falls back to limit" do
+      params = subject.send(:adjust_pagination_params, limit: 3)
+      params[:limit].should == 3
+    end
+
+    it "prefers page to offset" do
+      params = subject.send(:adjust_pagination_params, page: 2, offset: 0)
+      params[:offset].should == 10
+    end
+
+    it "falls back to offset" do
+      params = subject.send(:adjust_pagination_params, offset: 6)
+      params[:offset].should == 6
+    end
+  end
+end


### PR DESCRIPTION
support `:page` and `:per` pagination parameters a la Kaminari. `:page` is 1-indexed. a default limit of 10 is used ot calculate the offset if `:page` is provided but neither `:limit` nor `:per` is. `:page` and `:per` take precedence over `:offset` and `:limit` respectively.
