### PR TITLE
fixes #28: allow the logger to be configured

### DIFF
--- a/lib/balanced/client.rb
+++ b/lib/balanced/client.rb
@@ -14,6 +14,7 @@ module Balanced
       :port => 5000,
       :version => '1',
       :logging_level => 'WARN',
+      :logger => nil
     }
 
     attr_reader :conn
@@ -26,8 +27,12 @@ module Balanced
     end
 
     def build_conn
-      logger = Logger.new(STDOUT)
-      logger.level = Logger.const_get(DEFAULTS[:logging_level].to_s)
+      if config[:logger]
+        logger = config[:logger]
+      else
+        logger = Logger.new(STDOUT)
+        logger.level = Logger.const_get(config[:logging_level].to_s)
+      end
 
       Faraday.register_middleware :response,
           :handle_balanced_errors => lambda {Faraday::Response::RaiseBalancedError}


### PR DESCRIPTION
also respect the log level config rather than always using the default log level
