### PR TITLE
Implement `Client#respond_to?`

### DIFF
--- a/lib/balanced/client.rb
+++ b/lib/balanced/client.rb
@@ -67,14 +67,22 @@ module Balanced
     end
 
     private
+    
+    def respond_to?(method, include_private = false)
+      case method.to_sym
+      when :get, :post, :put, :delete
+        true
+      else
+        super method, include_private
+      end
+    end
 
     def method_missing(method, *args, &block)
-      case method
-      when :get, :post, :put, :delete
+      if respond_to? method
         conn.basic_auth(api_key, '') unless api_key.nil?
         conn.send method, *args
       else
-        super
+        super method, *args, &block
       end
     end
 

--- a/lib/balanced/client.rb
+++ b/lib/balanced/client.rb
@@ -66,19 +66,8 @@ module Balanced
       URI::HTTPS.build :host => config[:host], :port => config[:port]
     end
 
-    private
-    
-    def respond_to?(method, include_private = false)
-      case method.to_sym
-      when :get, :post, :put, :delete
-        true
-      else
-        super method, include_private
-      end
-    end
-
     def method_missing(method, *args, &block)
-      if respond_to? method
+      if is_http_method? method
         conn.basic_auth(api_key, '') unless api_key.nil?
         conn.send method, *args
       else
@@ -86,5 +75,18 @@ module Balanced
       end
     end
 
+    private
+    
+    def is_http_method? method
+      [:get, :post, :put, :delete].include? method
+    end
+    
+    def respond_to?(method, include_private = false)
+      if is_http_method? method
+        true
+      else
+        super method, include_private
+      end
+    end
   end
 end


### PR DESCRIPTION
It's an anti-pattern to redefine `method_missing` without redefining `respond_to?`.
See: http://stackoverflow.com/questions/291132/method-missing-gotchas-in-ruby

Moving `case` statement into redefined `respond_to?` and using it inside of redefined `method_missing`.
