### PR TITLE
Statically generate resource URL's from the marketplace_uri 

### DIFF
--- a/lib/balanced/error.rb
+++ b/lib/balanced/error.rb
@@ -1,7 +1,7 @@
 module Balanced
 
-  # Custom error class for rescuing from all Balanced errors
-  class Error < StandardError
+  # Custom error class for rescuing from all API response-related Balanced errors
+  class Error < ::StandardError
     attr_reader :response
 
     # @param [Hash] response the decoded json response body
@@ -34,6 +34,18 @@ module Balanced
           define_method("#{name}?") { !!body[name] }               # Present.
         }
       end
+    end
+  end
+
+  # General error class for non API response exceptions
+  class StandardError < Error
+    def initialize(message)
+      @message = message
+      super message
+    end
+
+    def error_message
+      @message
     end
   end
 

--- a/lib/balanced/error.rb
+++ b/lib/balanced/error.rb
@@ -4,13 +4,18 @@ module Balanced
   class Error < StandardError
     attr_reader :response
 
+    # @param [Hash] response the decoded json response body
     def initialize(response)
       @response = response
       super error_message
     end
 
+    # @return [Hash]
     def body
-      Utils.hash_with_indifferent_read_access response[:body]
+      @body ||= begin
+        return {} unless response[:body]
+        Utils.hash_with_indifferent_read_access(response[:body])
+      end
     end
 
     def error_message

--- a/lib/balanced/error.rb
+++ b/lib/balanced/error.rb
@@ -31,7 +31,7 @@ module Balanced
       body.keys.each do |name|
         self.class.instance_eval {
           define_method(name) { body[name] }                       # Get.
-          define_method("#{name}?") { !!body[name].nil? }          # Present.
+          define_method("#{name}?") { !!body[name] }               # Present.
         }
       end
     end

--- a/lib/balanced/error.rb
+++ b/lib/balanced/error.rb
@@ -39,13 +39,11 @@ module Balanced
 
   # General error class for non API response exceptions
   class StandardError < Error
+    attr_reader :message
+    alias :error_message :message
+
     def initialize(message)
       @message = message
-      super message
-    end
-
-    def error_message
-      @message
     end
   end
 

--- a/lib/balanced/resources/marketplace.rb
+++ b/lib/balanced/resources/marketplace.rb
@@ -23,6 +23,10 @@ module Balanced
       @marketplace_uri = uri
     end
 
+    def self.marketplace_exists?
+      !!marketplace_uri
+    end
+
     # @return [Markeplace]
     def save
       marketplace = super

--- a/lib/balanced/resources/marketplace.rb
+++ b/lib/balanced/resources/marketplace.rb
@@ -4,23 +4,21 @@ module Balanced
   class Marketplace
     include Balanced::Resource
 
+    @@marketplace_uri = nil
+
     # Returns an instance representing the marketplace associated with
     # the current API key.
     #
     # @return [Marketplace]
     def self.my_marketplace
       marketplace = Balanced::Merchant.me.marketplace
-      self.marketplace_uri = marketplace.uri if marketplace
+      @@marketplace_uri = marketplace.uri if marketplace
       marketplace
     end
 
     # @return [String, nil] the marketplace's URI
     def self.marketplace_uri
-      @marketplace_uri
-    end
-
-    def self.marketplace_uri=(uri)
-      @marketplace_uri = uri
+      @@marketplace_uri
     end
 
     def self.marketplace_exists?
@@ -30,7 +28,7 @@ module Balanced
     # @return [Marketplace]
     def save
       marketplace = super
-      self.class.marketplace_uri = marketplace.uri
+      @@marketplace_uri = marketplace.uri
       marketplace
     end
 

--- a/lib/balanced/resources/marketplace.rb
+++ b/lib/balanced/resources/marketplace.rb
@@ -27,7 +27,7 @@ module Balanced
       !!marketplace_uri
     end
 
-    # @return [Markeplace]
+    # @return [Marketplace]
     def save
       marketplace = super
       self.class.marketplace_uri = marketplace.uri

--- a/lib/balanced/resources/marketplace.rb
+++ b/lib/balanced/resources/marketplace.rb
@@ -9,7 +9,25 @@ module Balanced
     #
     # @return [Marketplace]
     def self.my_marketplace
-      Balanced::Merchant.me.marketplace
+      marketplace = Balanced::Merchant.me.marketplace
+      self.marketplace_uri = marketplace.uri if marketplace
+      marketplace
+    end
+
+    # @return [String, nil] the marketplace's URI
+    def self.marketplace_uri
+      @marketplace_uri
+    end
+
+    def self.marketplace_uri=(uri)
+      @marketplace_uri = uri
+    end
+
+    # @return [Markeplace]
+    def save
+      marketplace = super
+      self.class.marketplace_uri = marketplace.uri
+      marketplace
     end
 
     # Returns an instance representing the marketplace associated with

--- a/lib/balanced/resources/merchant.rb
+++ b/lib/balanced/resources/merchant.rb
@@ -1,4 +1,5 @@
 module Balanced
+  # Resource representing the marketplace merchant object.
   class Merchant
     include Balanced::Resource
 

--- a/lib/balanced/resources/resource.rb
+++ b/lib/balanced/resources/resource.rb
@@ -134,7 +134,7 @@ module Balanced
         instance.class.instance_eval {
           define_method(name) { @attributes[name] }                       # Get.
           define_method("#{name}=") { |value| @attributes[name] = value } # Set.
-          define_method("#{name}?") { !!@attributes[name].nil? }               # Present.
+          define_method("#{name}?") { !!@attributes[name] }               # Present.
         }
         instance.send("#{name}=".to_s, value)
       end

--- a/lib/balanced/resources/resource.rb
+++ b/lib/balanced/resources/resource.rb
@@ -96,7 +96,7 @@ module Balanced
       #
       #    if there's an api key, then the merchant is available
       #    if there's no api key, the only resources exposed are purely top level
-      if self == Balanced::Merchant or self == Balanced::Marketplace or self == Balanced::ApiKey
+      if self == Balanced::Merchant || self == Balanced::Marketplace || self == Balanced::ApiKey
         collection_path
       else
         if !Balanced::Marketplace.marketplace_exists?

--- a/lib/balanced/resources/resource.rb
+++ b/lib/balanced/resources/resource.rb
@@ -83,20 +83,27 @@ module Balanced
       Utils.underscore resource_name
     end
 
+    # Returns the resource URI for a given class.
+    #
+    # @example A Balanced::Account resource
+    #   Balanced::Account.uri # => "/v1/marketplaces/TEST-MP72zVdg2j9IiqRffW9lczRZ/accounts"
+    #
+    # @return [String] the uri of the instance or the class
     def uri
       # the uri of a particular resource depends if there's a marketplace created or not
       # if there's a marketplace, then all resources have their own uri from there and the top level ones
       # if there's not a marketplace
+      #
       #    if there's an api key, then the merchant is available
       #    if there's no api key, the only resources exposed are purely top level
       if self == Balanced::Merchant or self == Balanced::Marketplace or self == Balanced::ApiKey
         collection_path
       else
-        if Balanced::Marketplace.my_marketplace.nil?
+        if !Balanced::Marketplace.marketplace_exists?
           raise Balanced::StandardError, "#{self.name} is nested under a marketplace, which is not created or configured."
-        else
-          Balanced::Marketplace.my_marketplace.send(collection_name + '_uri')
         end
+
+        Balanced::Marketplace.marketplace_uri + "/#{collection_name}"
       end
     end
 

--- a/lib/balanced/resources/resource.rb
+++ b/lib/balanced/resources/resource.rb
@@ -93,7 +93,7 @@ module Balanced
         collection_path
       else
         if Balanced::Marketplace.my_marketplace.nil?
-          raise Balanced::Error, "#{self.name} is nested under a marketplace, which is not created or configured."
+          raise Balanced::StandardError, "#{self.name} is nested under a marketplace, which is not created or configured."
         else
           Balanced::Marketplace.my_marketplace.send(collection_name + '_uri')
         end

--- a/spec/balanced/error_spec.rb
+++ b/spec/balanced/error_spec.rb
@@ -33,3 +33,10 @@ describe Balanced::Error, '#body' do
     end
   end
 end
+
+describe Balanced::StandardError do
+  subject { Balanced::StandardError.new('ohnoe!') }
+
+  its(:message) { should == 'ohnoe!' }
+  its(:error_message) { should == 'ohnoe!' }
+end

--- a/spec/balanced/error_spec.rb
+++ b/spec/balanced/error_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe Balanced::Error, '#response' do
+  it "sets the response in the initializer" do
+    response = {status: 200}
+    Balanced::Error.new(response).response.should == response
+  end
+end
+
+describe Balanced::Error, '#body' do
+  it 'is constructed from the response[:body]' do
+    response = {body: {}}
+    error = Balanced::Error.new(response)
+    error.body.should == response[:body]
+  end
+
+  it "defaults to an empty hash when no body is passed" do
+    Balanced::Error.new({}).body.should == {}
+  end
+
+  describe "generating methods from response keys"  do
+    before do
+      response = {body: {foo: 'bar'}}
+      @error = Balanced::Error.new(response)
+    end
+
+    it 'generates a getter for each key' do
+      @error.foo.should == 'bar'
+    end
+
+    it 'generates a predicate method' do
+      @error.foo?.should be_true
+    end
+  end
+end

--- a/spec/balanced/resources/account_spec.rb
+++ b/spec/balanced/resources/account_spec.rb
@@ -14,7 +14,7 @@ describe Balanced::Account do
     context "when ApiKey is not configured" do
       use_vcr_cassette
       before do
-        Balanced::Marketplace.marketplace_uri = nil
+        Balanced::Marketplace.stub(:marketplace_uri) { nil }
         Balanced.configure nil
       end
 

--- a/spec/balanced/resources/account_spec.rb
+++ b/spec/balanced/resources/account_spec.rb
@@ -14,6 +14,7 @@ describe Balanced::Account do
     context "when ApiKey is not configured" do
       use_vcr_cassette
       before do
+        Balanced::Marketplace.marketplace_uri = nil
         Balanced.configure nil
       end
 

--- a/spec/balanced/resources/marketplace_spec.rb
+++ b/spec/balanced/resources/marketplace_spec.rb
@@ -128,3 +128,15 @@ describe Balanced::Marketplace, '.marketplace_uri' do
     end
   end
 end
+
+describe Balanced::Marketplace, '.marketplace_exists?' do
+  it 'returns false when nil' do
+    Balanced::Marketplace.marketplace_uri = nil
+    Balanced::Marketplace.marketplace_exists?.should == false
+  end
+
+  it 'returns true when not nil' do
+    Balanced::Marketplace.marketplace_uri = 'some uri'
+    Balanced::Marketplace.marketplace_exists?.should == true
+  end
+end

--- a/spec/balanced/resources/marketplace_spec.rb
+++ b/spec/balanced/resources/marketplace_spec.rb
@@ -106,7 +106,7 @@ describe Balanced::Marketplace, '.marketplace_uri' do
 
       # creating the marketplace sets `Balanced::Marketplace.marketplace_uri`,
       # so we need to clear it out here to get the test in the right state
-      Balanced::Marketplace.marketplace_uri = nil
+      Balanced::Marketplace.class_variable_set(:@@marketplace_uri, nil)
 
       expect {
         Balanced::Marketplace.my_marketplace
@@ -121,7 +121,6 @@ describe Balanced::Marketplace, '.marketplace_uri' do
       api_key = Balanced::ApiKey.new.save
       Balanced.configure api_key.secret
 
-      Balanced::Marketplace.marketplace_uri = nil
       res = Balanced::Marketplace.new.save
       Balanced::Marketplace.marketplace_uri.should == res.uri
       Balanced::Marketplace.marketplace_uri.nil?.should be_false
@@ -131,12 +130,12 @@ end
 
 describe Balanced::Marketplace, '.marketplace_exists?' do
   it 'returns false when nil' do
-    Balanced::Marketplace.marketplace_uri = nil
+    Balanced::Marketplace.stub(:marketplace_uri) { nil }
     Balanced::Marketplace.marketplace_exists?.should == false
   end
 
   it 'returns true when not nil' do
-    Balanced::Marketplace.marketplace_uri = 'some uri'
+    Balanced::Marketplace.stub(:marketplace_uri) { 'some uri' }
     Balanced::Marketplace.marketplace_exists?.should == true
   end
 end

--- a/spec/balanced/resources/marketplace_spec.rb
+++ b/spec/balanced/resources/marketplace_spec.rb
@@ -95,3 +95,36 @@ describe Balanced::Marketplace do
   end
 end
 
+describe Balanced::Marketplace, '.marketplace_uri' do
+  context 'when invoking .my_marketplace' do
+    use_vcr_cassette
+
+    it 'sets the marketplace_id after the first call' do
+      api_key = Balanced::ApiKey.new.save
+      Balanced.configure api_key.secret
+      marketplace = Balanced::Marketplace.new.save
+
+      # creating the marketplace sets `Balanced::Marketplace.marketplace_uri`,
+      # so we need to clear it out here to get the test in the right state
+      Balanced::Marketplace.marketplace_uri = nil
+
+      expect {
+        Balanced::Marketplace.my_marketplace
+      }.to change { Balanced::Marketplace.marketplace_uri }.from(nil).to(marketplace.uri)
+    end
+  end
+
+  context 'when creating a Balanced::Marketplace resource' do
+    use_vcr_cassette
+
+    it 'sets the marketplace_uri' do
+      api_key = Balanced::ApiKey.new.save
+      Balanced.configure api_key.secret
+
+      Balanced::Marketplace.marketplace_uri = nil
+      res = Balanced::Marketplace.new.save
+      Balanced::Marketplace.marketplace_uri.should == res.uri
+      Balanced::Marketplace.marketplace_uri.nil?.should be_false
+    end
+  end
+end

--- a/spec/balanced/resources/merchant_spec.rb
+++ b/spec/balanced/resources/merchant_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+describe Balanced::Merchant, '.uri' do
+  subject { Balanced::Merchant }
+  its(:uri) { should == '/v1/merchants' }
+end

--- a/spec/balanced/resources/resource_spec.rb
+++ b/spec/balanced/resources/resource_spec.rb
@@ -5,7 +5,7 @@ describe Balanced::Resource, '.uri' do
 
   describe "before the marketplace is configured" do
     it 'raises an exception' do
-      Balanced::Marketplace.marketplace_uri = nil
+      Balanced::Marketplace.stub(:marketplace_uri) { nil }
       expect {
         Balanced::Account.uri
       }.to raise_error(Balanced::StandardError, "Balanced::Account is nested under a marketplace, which is not created or configured.")
@@ -14,8 +14,7 @@ describe Balanced::Resource, '.uri' do
 
   describe 'when the marketplace is configured' do
     it 'returns the resource uri corresponding to the resource name passed in' do
-      marketplace_uri = '/v1/marketplaces/TEST-MPynogsPWE3xLMnLbEbuM0g'
-      Balanced::Marketplace.marketplace_uri = '/v1/marketplaces/TEST-MPynogsPWE3xLMnLbEbuM0g'
+      Balanced::Marketplace.stub(:marketplace_uri) { '/v1/marketplaces/TEST-MPynogsPWE3xLMnLbEbuM0g' }
       Balanced::Account.uri.should == '/v1/marketplaces/TEST-MPynogsPWE3xLMnLbEbuM0g/accounts'
     end
   end

--- a/spec/balanced/resources/resource_spec.rb
+++ b/spec/balanced/resources/resource_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe Balanced::Resource, 'loading a resource and generating methods from the response body' do
+  use_vcr_cassette
+
+  before do
+    make_marketplace
+    @account = Balanced::Account.new(email: 'user@example.com', name: 'John Doe').save
+  end
+
+  it 'generates a predicate method' do
+    @account.name?.should be_true
+  end
+
+  it 'generates a getter method' do
+    @account.name.should == 'John Doe'
+  end
+
+  it 'generates a setter' do
+    @account.name = 'Bob Bobberson'
+    @account.name.should == 'Bob Bobberson'
+  end
+end

--- a/spec/balanced/resources/resource_spec.rb
+++ b/spec/balanced/resources/resource_spec.rb
@@ -1,5 +1,26 @@
 require 'spec_helper'
 
+describe Balanced::Resource, '.uri' do
+  use_vcr_cassette
+
+  describe "before the marketplace is configured" do
+    it 'raises an exception' do
+      Balanced::Marketplace.marketplace_uri = nil
+      expect {
+        Balanced::Account.uri
+      }.to raise_error(Balanced::StandardError, "Balanced::Account is nested under a marketplace, which is not created or configured.")
+    end
+  end
+
+  describe 'when the marketplace is configured' do
+    it 'returns the resource uri corresponding to the resource name passed in' do
+      marketplace_uri = '/v1/marketplaces/TEST-MPynogsPWE3xLMnLbEbuM0g'
+      Balanced::Marketplace.marketplace_uri = '/v1/marketplaces/TEST-MPynogsPWE3xLMnLbEbuM0g'
+      Balanced::Account.uri.should == '/v1/marketplaces/TEST-MPynogsPWE3xLMnLbEbuM0g/accounts'
+    end
+  end
+end
+
 describe Balanced::Resource, 'loading a resource and generating methods from the response body' do
   use_vcr_cassette
 

--- a/spec/balanced/resources/transactions_spec.rb
+++ b/spec/balanced/resources/transactions_spec.rb
@@ -8,6 +8,7 @@ describe Balanced::Transaction do
     api_key = Balanced::ApiKey.new.save
     Balanced.configure api_key.secret
     @marketplace = Balanced::Marketplace.new.save
+
     @merchant_attributes = {
         :type => "person",
         :name => "Billy Jones",

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,13 @@ end
 
 RSpec.configure do |c|
   c.extend VCR::RSpec::Macros
+
+  # @return [Balanced::Marketplace]
+  def make_marketplace
+    api_key = Balanced::ApiKey.new.save
+    Balanced.configure api_key.secret
+    Balanced::Marketplace.new.save
+  end
 end
 
 


### PR DESCRIPTION
- #41 - Memoizes the marketplace_uri in `Balanced::Marketplace.marketplace_uri`
- #45 - Addresses some logical bugs generating predicate methods
- #44 - Fixes a bug with the `Balanced::Error` class

This PR is primarily a performance enhancement. The change introduced in f3df3ae changes resource URL generation from using properties returned by the `Balanced::Marketplace.my_marketplace` method to statically building URL's based upon the marketplace URI, which is now cached. So, instead of relying on the `GET /v1/marketplaces/:id` call to give a url like `/v1/marketplaces/:marketplace_id/accounts`, we simply construct this string in the code if we have the `marketplace_uri` available.

We discussed memoizing the entire `.my_marketplace` method, but there are dynamic properties returned in that response that make that solution infeasible.
