### PR TITLE
Clarified terminology

### DIFF
--- a/lib/balanced/resources/account.rb
+++ b/lib/balanced/resources/account.rb
@@ -31,7 +31,7 @@ module Balanced
     def debit *args
       options = args.last.is_a?(Hash) ? args.pop : {}
       amount = args[0] || options.fetch(:amount) { nil }
-      soft_descriptor = args[1] || options.fetch(:appears_on_statement_as) { nil }
+      appears_on_statement_as = args[1] || options.fetch(:appears_on_statement_as) { nil }
       hold_uri = args[2] || options.fetch(:hold_uri) { nil }
       meta = args[3] || options.fetch(:meta) { nil }
       description = args[4] || options.fetch(:description) { nil }
@@ -40,7 +40,7 @@ module Balanced
       debit = Debit.new(
           :uri => self.debits_uri,
           :amount => amount,
-          :appears_on_statement_as => soft_descriptor,
+          :appears_on_statement_as => appears_on_statement_as,
           :hold_uri => hold_uri,
           :meta => meta,
           :description => description,

--- a/lib/balanced/resources/bank_account.rb
+++ b/lib/balanced/resources/bank_account.rb
@@ -36,11 +36,11 @@ module Balanced
     def debit *args
       options = args.last.is_a?(Hash) ? args.pop : {}
       amount = args[0] || options.fetch(:amount) { nil }
-      soft_descriptor = args[1] || options.fetch(:appears_on_statement_as) { nil }
+      appears_on_statement_as = args[1] || options.fetch(:appears_on_statement_as) { nil }
       meta = args[2] || options.fetch(:meta) { nil }
       description = args[3] || options.fetch(:description) { nil }
 
-      self.account.debit(amount, soft_descriptor, meta, description, self.uri)
+      self.account.debit(amount, appears_on_statement_as, meta, description, self.uri)
     end
 
     # Creates a Credit of funds from your Marketplace's escrow account to this
@@ -59,7 +59,7 @@ module Balanced
         ).save
       else
         meta = args[2] || options.fetch(:meta) { nil }
-        soft_descriptor = args[3] || options.fetch(:appears_on_statement_as) { nil }
+        appears_on_statement_as = args[3] || options.fetch(:appears_on_statement_as) { nil }
         destination_url = args[4] || options.fetch(:destination_uri) { self.uri }
         self.account.credit(amount, meta, description, destination_uri, appears_on_statement_as)
       end


### PR DESCRIPTION
soft_descriptor should probably just be appears_on_statement_as, as that is used in documentation and other resources.
