### PR TITLE
README Troubleshooting OpenSSL

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -6,3 +6,4 @@ Ivan Lyutov
 Alex Sharp
 Marc Sherry
 Joonas Bergius
+Ben Mills

--- a/README.md
+++ b/README.md
@@ -69,3 +69,10 @@ Documentation is built using YARD - http://rubydoc.info/docs/yard
     export AMAZON_ACCESS_KEY_ID='xxx'
     export AMAZON_SECRET_ACCESS_KEY='yyy' 
     ./upload_docs.rb
+
+### Troubleshooting
+
+#####OpenSSL
+    SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed (OpenSSL::SSL::SSLError)
+
+The machine's Ruby/OpenSSL environment can't find any root certificates to trust. Please refer [here](http://www.google.com/search?q=SSL+connect+returned=1+errno=0+state=SSLv3) to find the best solution for your environment.


### PR DESCRIPTION
Added troubleshooting section to README.

Added OpenSSL section with general info for the SSL_connect error related to the Ruby/OpenSSL environment being unable to find any root certificates to trust. Includes a link to Google search results to find the best solution for the machine's environment.
