### PR TITLE
Resolved :rubygems is deprecated

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in balanced.gemspec
 


### PR DESCRIPTION
Resolved "The source :rubygems is deprecated because HTTP requests are insecure."
