### PR TITLE
Allow faraday http adapter to be set through Balanced.configure

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ group :development do
 end
 
 group :test do
+  gem 'net-http-persistent'
   gem "rspec", '~> 2.13.0'
   gem "rake", '~> 10.0.3'
   gem "vcr", '~> 2.4.0'

--- a/lib/balanced/client.rb
+++ b/lib/balanced/client.rb
@@ -17,7 +17,8 @@ module Balanced
       :connection_timeout => 30,
       :read_timeout => 30,
       :logger => nil,
-      :ssl_verify => true
+      :ssl_verify => true,
+      :adapter => Faraday.default_adapter
     }
 
     attr_reader :conn
@@ -56,7 +57,7 @@ module Balanced
         cxn.response :handle_balanced_errors
         cxn.response :json
         # cxn.response :raise_error  # raise exceptions on 40x, 50x responses
-        cxn.adapter  Faraday.default_adapter
+        cxn.adapter  config[:adapter]
       end
       conn.path_prefix = '/'
       conn.headers['User-Agent'] = "balanced-ruby/#{Balanced::VERSION}"

--- a/lib/balanced/client.rb
+++ b/lib/balanced/client.rb
@@ -7,7 +7,7 @@ require "balanced_exception_middleware"
 
 module Balanced
   class Client
-  
+
     DEFAULTS = {
       :scheme => 'http',
       :host => 'localhost',
@@ -18,7 +18,7 @@ module Balanced
       :read_timeout => 30,
       :logger => nil,
       :ssl_verify => true,
-      :adapter => Faraday.default_adapter
+      :faraday_adapter => Faraday.default_adapter
     }
 
     attr_reader :conn
@@ -57,7 +57,7 @@ module Balanced
         cxn.response :handle_balanced_errors
         cxn.response :json
         # cxn.response :raise_error  # raise exceptions on 40x, 50x responses
-        cxn.adapter  config[:adapter]
+        cxn.adapter  config[:faraday_adapter]
       end
       conn.path_prefix = '/'
       conn.headers['User-Agent'] = "balanced-ruby/#{Balanced::VERSION}"

--- a/spec/balanced_spec.rb
+++ b/spec/balanced_spec.rb
@@ -8,7 +8,7 @@ describe Balanced do
     end
 
     it 'allows the user to set it' do
-      client = Balanced.configure 'secret', :adapter => :net_http_persistent
+      client = Balanced.configure 'secret', :farday_adapter => :net_http_persistent
       client.conn.builder.handlers.should include Faraday::Adapter::NetHttpPersistent
       client.conn.builder.handlers.should_not include Faraday::Adapter::NetHttp
     end

--- a/spec/balanced_spec.rb
+++ b/spec/balanced_spec.rb
@@ -8,7 +8,7 @@ describe Balanced do
     end
 
     it 'allows the user to set it' do
-      client = Balanced.configure 'secret', :farday_adapter => :net_http_persistent
+      client = Balanced.configure 'secret', :faraday_adapter => :net_http_persistent
       client.conn.builder.handlers.should include Faraday::Adapter::NetHttpPersistent
       client.conn.builder.handlers.should_not include Faraday::Adapter::NetHttp
     end

--- a/spec/balanced_spec.rb
+++ b/spec/balanced_spec.rb
@@ -1,6 +1,19 @@
 require "spec_helper"
 
 describe Balanced do
+  describe 'configuring the faraday http adapter' do
+    it 'sets it to net http when nothing is passed in' do
+      client = Balanced.configure 'secret'
+      client.conn.builder.handlers.should include Faraday::Adapter::NetHttp
+    end
+
+    it 'allows the user to set it' do
+      client = Balanced.configure 'secret', :adapter => :net_http_persistent
+      client.conn.builder.handlers.should include Faraday::Adapter::NetHttpPersistent
+      client.conn.builder.handlers.should_not include Faraday::Adapter::NetHttp
+    end
+  end
+
   describe "configure", :vcr do
     before do
       @api_key = Balanced::ApiKey.new.save


### PR DESCRIPTION
This enables using alternate http clients than Faraday's default, net/http.
