### PR TITLE
Associating a card with an account fails on version 0.5.3

### DIFF
--- a/lib/balanced/resources/resource.rb
+++ b/lib/balanced/resources/resource.rb
@@ -141,12 +141,14 @@ module Balanced
     def construct_from_response payload
       payload = Balanced::Utils.hash_with_indifferent_read_access payload
       return payload if payload[:uri].nil?
+      payload.reject! { |k, v| v.nil? } # remove nil values from the payload
       klass = Balanced.from_uri(payload[:uri])
       instance = klass.new payload
       payload.each do |name, value|
         klass.class_eval {
           attr_accessor name.to_s
         }
+
         # here is where our interpretations will begin.
         # if the value is a sub-resource, lets instantiate the class
         # and set it correctly

--- a/spec/balanced/resources/resource_spec.rb
+++ b/spec/balanced/resources/resource_spec.rb
@@ -37,3 +37,39 @@ describe Balanced::Resource, 'loading a resource and generating methods from the
     @account.name.should == 'Bob Bobberson'
   end
 end
+
+describe Balanced::Resource, '.construct_from_response' do
+  Klass = Class.new do
+    include Balanced::Resource
+  end
+
+  it 'returns an instance of the class indicated by the uri property' do
+    account = Klass.construct_from_response(uri: '/v1/marketplaces/123/accounts/123')
+    account.should be_instance_of Balanced::Account
+  end
+
+  describe 'a nil attribute' do
+    let(:payload) do
+      { uri: '/v1/marketplaces/123/accounts/234',
+        foo: nil }
+    end
+
+    subject { Klass.construct_from_response(payload) }
+
+    it 'does not set the attributes hash for a nil attribute' do
+      subject.attributes.keys.should_not include 'foo'
+    end
+
+    it 'does not generate a getter method' do
+      subject.methods.should_not include :foo
+    end
+
+    it 'does not generate a setter method' do
+      subject.methods.should_not include :foo=
+    end
+
+    it 'does not generate a predicate method' do
+      subject.methods.should_not include :foo?
+    end
+  end
+end


### PR DESCRIPTION
If you attempt to assign an account_uri to a `Balanced::Card` object, this fails with a 400 error:

`
Balanced::BadRequest: Balanced::BadRequest(400)::Bad Request:: PUT https://api.balancedpayments.com/v1/marketplaces/XXX/cards/YYY: request: Only one of [account_uri|account] can be specified Your request id is OHMZZZ.
`

The problem here is that I didn't set the `account` object. This seems like a pretty straightforward client error.
