### PR TITLE
Allow card and bank account objects as params

### DIFF
--- a/lib/balanced/resources/account.rb
+++ b/lib/balanced/resources/account.rb
@@ -112,8 +112,9 @@ module Balanced
     # Associates the Card represented by +card_uri+ with this Account.
     #
     # @return [Card]
-    def add_card card_uri
-      self.card_uri = card_uri
+    def add_card(card)
+      card.save if card.kind_of?(Balanced::Card) && card.hash.nil?
+      self.card_uri = Balanced::Utils.extract_uri_from_object(card)
       save
     end
 
@@ -121,8 +122,11 @@ module Balanced
     # Account.
     #
     # @return [BankAccount]
-    def add_bank_account bank_account_uri
-      self.bank_account_uri = bank_account_uri
+    def add_bank_account(bank_account)
+      if bank_account.kind_of?(Balanced::BankAccount) && bank_account.hash.nil?
+        bank_account.save
+      end
+      self.bank_account_uri = Balanced::Utils.extract_uri_from_object(bank_account)
       save
     end
 


### PR DESCRIPTION
Changed Account.add_card and Account.add_bank_account to accept objects or URIs.

Resolves #91
