### PR TITLE
Add find_by_email to Customer

### DIFF
--- a/lib/balanced/resources/customer.rb
+++ b/lib/balanced/resources/customer.rb
@@ -19,6 +19,15 @@ module Balanced
       super attributes
     end
 
+    # Attempts to find an existing customer by email
+    #
+    # @param [String] email An email of a customer
+    # @return [Customer] if customer is found
+    # @return [nil] if customer is not found
+    def self.find_by_email email
+      self.find(:first, :email_address => email)
+    end
+    
     def debit(options = {})
       amount = options[:amount]
       appears_on_statement_as = options[:appears_on_statement_as]

--- a/lib/balanced/resources/customer.rb
+++ b/lib/balanced/resources/customer.rb
@@ -21,6 +21,10 @@ module Balanced
 
     # Attempts to find an existing customer by email
     #
+    # *NOTE:* There is no unique constraint on email_address.
+    #         Multiple customers with the same email may exist.
+    #         Only one Customer is returned.
+    #
     # @param [String] email An email of a customer
     # @return [Customer] if customer is found
     # @return [nil] if customer is not found

--- a/lib/balanced/resources/customer.rb
+++ b/lib/balanced/resources/customer.rb
@@ -29,7 +29,7 @@ module Balanced
     # @return [Customer] if customer is found
     # @return [nil] if customer is not found
     def self.find_by_email email
-      self.find(:first, :email_address => email)
+      self.find(:first, :email => email)
     end
     
     def debit(options = {})

--- a/spec/balanced/resources/customer_spec.rb
+++ b/spec/balanced/resources/customer_spec.rb
@@ -144,6 +144,37 @@ describe Balanced::Customer, :vcr do
       end
     end
 
+    describe "#find_by_email", :vcr => { :record => :new_episodes } do
+      before do
+        api_key = Balanced::ApiKey.new.save
+        Balanced.configure api_key.secret
+        @marketplace = Balanced::Marketplace.new.save
+        customer = @marketplace.create_customer(
+          :name           => "Bill",
+          :email          => "bill@bill.com",
+          :business_name  => "Bill Inc.",
+          :ssn_last4      => "1234",
+          :address => {
+            :line1 => "1234 1st Street",
+            :city  => "San Francisco",
+            :state => "CA"
+          }
+        ).save
+      end
+
+      context "email address is in system", :vcr => { :record => :new_episodes } do
+        it "should return customer object" do
+          Balanced::Customer.find_by_email("bill@bill.com").should be_instance_of Balanced::Customer
+        end
+      end
+
+      context "email address does not exist", :vcr => { :record => :new_episodes } do
+        it "should return nil" do
+          Balanced::Customer.find_by_email("foo@bar.com").should be_nil
+        end
+      end
+    end
+    
     describe "#debit" do
       before do
         @customer = @marketplace.create_customer


### PR DESCRIPTION
Customer has no means to find a Customer by email address. A Balanced customer requested this ability.

Resolves #106
