### PR TITLE
Method missing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ gem "faraday_middleware"
 
 group :development do
   gem "yard"
-  gem "ruby-debug19"
   gem "guard", '~> 1.6.2'
   gem "guard-rspec", '~> 2.4.1'
 end

--- a/examples/examples.rb
+++ b/examples/examples.rb
@@ -137,6 +137,8 @@ bank_account = Balanced::BankAccount.new(
     :type => "checking"
 ).save
 
+raise "Should not have an account" if bank_account.has_account?
+
 puts "now let's credit it, the super-simple way"
 credit = bank_account.credit(
     :amount => 500


### PR DESCRIPTION
This piece of code is a bit disgusting. We will clean it up soon, but basically, we were creating closures using this code snippet but those closures were transferred to the actual classes themselves so you would have something like BankAccount.new.account and this will give the last closure added for a BankAccount even if it has nothing to do with the actual class itself.

This caused some weird errors, so the best thing to do was to just move this piece of code and "dynamically" enable it for all method requests that are essentially #{method}_uri.

This solves the acute problem, for now.
