### PR TITLE
delete -> unstore

### DIFF
--- a/lib/balanced.rb
+++ b/lib/balanced.rb
@@ -71,10 +71,10 @@ module Balanced
       self.client.put *args
     end
 
-    def delete(*args, &block)
-      self.client.delete *args
+    def unstore(*args, &block)
+      self.client.unstore *args
     end
-
+    alias_method :delete, :unstore
   end
 
   # configure on import so we don't have to configure for creating

--- a/lib/balanced/client.rb
+++ b/lib/balanced/client.rb
@@ -77,6 +77,12 @@ module Balanced
                      :scheme => config[:scheme]})
     end
 
+    # alias_method doesn't work with method_missing, so we manually
+    # delegate
+    def unstore(*args, &block)
+      delete(*args, &block)
+    end
+
     def method_missing(method, *args, &block)
       if is_http_method? method
         conn.basic_auth(api_key, '') unless api_key.nil?

--- a/lib/balanced/resources/card_hold.rb
+++ b/lib/balanced/resources/card_hold.rb
@@ -28,9 +28,10 @@ module Balanced
       debit
     end
 
-    def delete
+    def unstore
       destroy
     end
+    alias_method :delete, :unstore
 
   end
 end

--- a/lib/balanced/resources/resource.rb
+++ b/lib/balanced/resources/resource.rb
@@ -126,13 +126,10 @@ module Balanced
 
     private :response
 
-    def destroy
-      Balanced.delete @attributes[:href]
-    end
-
     def unstore
-      destroy
+      Balanced.unstore @attributes[:href]
     end
+    alias_method :destroy, :unstore
 
     def reload(the_response = nil)
       if the_response


### PR DESCRIPTION
We want to move to using 'unstore' as the preferred name for this action.

Keeping delete around since it's basically zero maintenance burden. No reason
to force people to re-write code they've already written.
