### PR TITLE
Change faraday version constraint to pessimistic

### DIFF
--- a/balanced.gemspec
+++ b/balanced.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.summary       = %q{https://docs.balancedpayments.com/}
   gem.homepage      = "https://www.balancedpayments.com"
 
-  gem.add_dependency("faraday", '>= 0.8.6')
+  gem.add_dependency("faraday", '~> 0.8.6')
   gem.add_dependency("faraday_middleware", '~> 0.9.0')
   gem.add_dependency("addressable", '~> 2.3.5')
 


### PR DESCRIPTION
The current dependency constraint of '>=0.8.6' for faraday is causing
`bundle outdated` to error out on a project I am working on. This is
due to faraday-middleware being incompatible with faraday 0.9 and
bundler trying to update to faraday 0.9 from the lax balanced
constraint.

By switching to pessimistic versioning, we can avoid this dependency
problem without limiting users to any different version of faraday
since faraday-middleware shares this version constraint.
