### PR TITLE
Fixes balanced/balanced-ruby#164

### DIFF
--- a/lib/balanced/error.rb
+++ b/lib/balanced/error.rb
@@ -5,9 +5,11 @@ module Balanced
     attr_reader :response
 
     # @param [Hash] response the decoded json response body
-    def initialize(response)
+    def initialize(response=nil)
       @response = response
-      super error_message
+      unless response.nil?
+        super error_message
+      end
     end
 
     # @return [Hash]

--- a/lib/balanced/resources/resource.rb
+++ b/lib/balanced/resources/resource.rb
@@ -257,6 +257,11 @@ module Balanced
       end
 
       def fetch(*arguments)
+        if arguments.nil? ||
+           arguments.empty?  ||
+           arguments[0].empty?
+          raise Balanced::NotFound
+        end
         scope = arguments.slice!(0)
         options = arguments.slice!(0) || {}
         case scope

--- a/spec/balanced/error_spec.rb
+++ b/spec/balanced/error_spec.rb
@@ -54,3 +54,21 @@ describe Balanced::UnassociatedCardError do
     should == "The Balanced::Card with uri=#{card.attributes['uri']} is not associated to a customer"
   end
 end
+
+describe 'Fetch NotFound' do
+  context 'href nil' do
+    it do
+      expect {
+        Balanced::Customer.fetch()
+      }.to raise_exception(Balanced::NotFound)
+    end
+  end
+
+  context 'href empty string' do
+    it do
+      expect {
+        Balanced::Customer.fetch("")
+      }.to raise_exception(Balanced::NotFound)
+    end
+  end
+end


### PR DESCRIPTION
fetch with a nil or empty string should raise Balanced::NotFound

@steveklabnik Would you sanity-check this.
