### PR TITLE
adds the ability to send the meta attribute in several calls that it was...

### DIFF
--- a/lib/balanced/resources/credit.rb
+++ b/lib/balanced/resources/credit.rb
@@ -13,14 +13,10 @@ module Balanced
     define_hypermedia_types [:credits]
 
     def reverse(options={})
-      amount = options[:amount]
-      description = options[:description]
+      options[:href] = self.reversals.href
+      puts "OPTIONS _______ #{options.inspect}"
 
-      reversal = Reversal.new(
-          :href => self.reversals.href,
-          :amount => amount,
-          :description => description
-      )
+      reversal = Reversal.new(options)
       reversal.save
     end
 

--- a/lib/balanced/resources/credit.rb
+++ b/lib/balanced/resources/credit.rb
@@ -14,7 +14,6 @@ module Balanced
 
     def reverse(options={})
       options[:href] = self.reversals.href
-      puts "OPTIONS _______ #{options.inspect}"
 
       reversal = Reversal.new(options)
       reversal.save

--- a/lib/balanced/resources/debit.rb
+++ b/lib/balanced/resources/debit.rb
@@ -24,14 +24,9 @@ module Balanced
     # @return [Refund]
     def refund(options={})
 
-      amount = options[:amount]
-      description = options[:description]
+      options[:href] = self.refunds.href
 
-      refund = Refund.new(
-          :href => self.refunds.href,
-          :amount => amount,
-          :description => description
-      )
+      refund = Refund.new(options)
       refund.save
     end
 

--- a/spec/balanced/resources/credit_spec.rb
+++ b/spec/balanced/resources/credit_spec.rb
@@ -13,6 +13,7 @@ describe Balanced::Credit, :vcr do
 
     # An initial balance for the marketplace
     card.debit(:amount => 1000000)
+    @meta = {"order_id" => "1111"}
   end
 
   describe '#create', :vcr do
@@ -25,7 +26,8 @@ describe Balanced::Credit, :vcr do
               :account_number => '0987654321',
               :name => 'Timmy T. McTimmerson',
               :type => 'checking'
-          }
+          },
+          :meta => @meta
       ).save
     end
 
@@ -37,6 +39,11 @@ describe Balanced::Credit, :vcr do
     describe 'customer', :vcr do
       subject { @credit.customer }
       it { should be_nil }
+    end
+
+    describe 'meta', :vcr do
+      subject { @credit.meta }
+      it { should eq @meta }
     end
 
   end
@@ -51,9 +58,10 @@ describe Balanced::Credit, :vcr do
               :account_number => '0987654321',
               :name => 'Timmy T. McTimmerson',
               :type => 'checking'
-          }
+          },
+          :meta => @meta
       ).save
-      @reversal = @credit.reverse
+      @reversal = @credit.reverse({:meta => @meta})
     end
 
     describe '#amount', :vcr do
@@ -65,6 +73,12 @@ describe Balanced::Credit, :vcr do
       subject { @reversal }
       it { should be_instance_of Balanced::Reversal }
     end
+
+    describe '#meta', :vcr do
+      subject { @reversal.meta }
+      it { should == @meta }
+    end
+
   end
 
   describe 'credit with underwritten customer' do
@@ -75,7 +89,8 @@ describe Balanced::Credit, :vcr do
           :dob_year => 1963,
           :address => {
               :postal_code => '48120'
-          }
+          },
+          :meta => @meta
       ).save
       @bank_account = Balanced::BankAccount.new(
           :routing_number => '321174851',
@@ -86,7 +101,8 @@ describe Balanced::Credit, :vcr do
       @bank_account.associate_to_customer(@customer)
       @credit = @bank_account.credit(
           :amount => 5000,
-          :description => 'A sweet ride'
+          :description => 'A sweet ride',
+          :meta => @meta
       )
     end
 
@@ -103,6 +119,11 @@ describe Balanced::Credit, :vcr do
     describe 'status' do
       subject { @credit.status }
       it { should eq 'succeeded' }
+    end
+
+    describe 'meta', :vcr do
+      subject { @credit.meta }
+      it { should eq @meta }
     end
   end
 end

--- a/spec/balanced/resources/debit_spec.rb
+++ b/spec/balanced/resources/debit_spec.rb
@@ -61,6 +61,9 @@ describe Balanced::Debit, :vcr do
   end
 
   describe '#refund', :vcr do
+    before do
+      @meta = {"order_id" => "11111"}
+    end
     subject do
       debit = Balanced::Debit.new(
           :amount => 1234,
@@ -68,15 +71,17 @@ describe Balanced::Debit, :vcr do
               :number => '5105105105105100',
               :expiration_month => '12',
               :expiration_year => '2015'
-          })
+          },
+          :meta => @meta)
       debit.save
-      refund = debit.refund
+      refund = debit.refund({:meta => @meta})
       refund
     end
 
     it { should_not be_nil }
     it { should be_instance_of Balanced::Refund }
     its(:amount) { should eql 1234 }
+    its(:meta) {should eq @meta}
 
   end
 end

--- a/spec/balanced/resources/order_spec.rb
+++ b/spec/balanced/resources/order_spec.rb
@@ -58,34 +58,39 @@ describe Balanced::Order, :vcr, :marketplace => true do
       @debit_statement_message = 'Debit Message'
       @credit_description = 'Credit Description'
       @credit_statement_message = 'Credit Message'
-      
+      @meta = {"order_id" => "1111"}
+
       debit = @order.debit_from(
           :source => @card,
           :amount => 10000,
           :appears_on_statement_as => @debit_statement_message,
-          :description => @debit_description
+          :description => @debit_description,
+          :meta => @meta
       )
 
       @order.reload
       @order.amount.should eq 10000
       @order.amount_escrowed.should eq 10000
-      
+
       debit.description.should eq @debit_description
+      debit.meta.should eq @meta
       debit.appears_on_statement_as.should eq "BAL*" << @debit_statement_message
 
       credit = @order.credit_to(
           :destination => @bank_account,
           :amount => 8000,
           :appears_on_statement_as => @credit_statement_message,
-          :description => @credit_description
+          :description => @credit_description,
+          :meta => @meta
       )
-      
+
       @order.reload
       @order.amount.should eq 10000
       @order.amount_escrowed.should eq 2000
       @order.debits.map { |d| d.href }.should include(debit.href)
-      
+
       credit.description.should eq @credit_description
+      credit.meta.should eq @meta
       credit.appears_on_statement_as.should eq @credit_statement_message
     end
 


### PR DESCRIPTION
... left out on.

Pretty simple fix, there were several call (especially when using orders) that only allow specific options to be included. This simply adds the meta attribute to those allowed options.

Other calls simply pass the options directly to Balanced, so they were allowing the meta attribute to be assigned. 

I didn't include any tests for this, since there are no other examples of tests for optional attributes in there, but all the current test were still passing with this change. 
