### PR TITLE
Adding :appears_on_statement_as for Orders

### DIFF
--- a/lib/balanced/resources/order.rb
+++ b/lib/balanced/resources/order.rb
@@ -32,10 +32,16 @@ module Balanced
 
       source = options[:source]
       amount = options[:amount]
+      
+      # extra parameters for labeling transactions 
+      description = options[:description]
+      appears_on_statement_as = options[:appears_on_statement_as]
 
       debit = source.debit(
           :amount => amount,
-          :order => self.href
+          :order => self.href,
+          :appears_on_statement_as => appears_on_statement_as,
+          :description => description
       )
 
       debit
@@ -43,10 +49,23 @@ module Balanced
 
     def credit_to(options={})
       Balanced::Utils.assert_required_keys(options, :required => [:destination, :amount])
+      
       destination = options[:destination]
       amount = options[:amount]
+      
+      # extra parameters for labeling transactions 
+      description = options[:description]
+      appears_on_statement_as = options[:appears_on_statement_as]
+      
       # should have a way here to disburse more funds to another account, but not required
-      destination.credit(:amount => amount, :order => self.href)
+      credit = destination.credit(
+        :amount => amount, 
+        :order => self.href,
+        :appears_on_statement_as => appears_on_statement_as,
+        :description => description
+      )
+        
+      credit
     end
 
     private

--- a/lib/balanced/resources/order.rb
+++ b/lib/balanced/resources/order.rb
@@ -30,40 +30,22 @@ module Balanced
     def debit_from(options={})
       Balanced::Utils.assert_required_keys(options, :required => [:source, :amount])
 
+      options[:order] = self.href
       source = options[:source]
-      amount = options[:amount]
       
-      # extra parameters for labeling transactions 
-      description = options[:description]
-      appears_on_statement_as = options[:appears_on_statement_as]
-
-      debit = source.debit(
-          :amount => amount,
-          :order => self.href,
-          :appears_on_statement_as => appears_on_statement_as,
-          :description => description
-      )
-
+      debit = source.debit(options)
+      
       debit
     end
 
     def credit_to(options={})
       Balanced::Utils.assert_required_keys(options, :required => [:destination, :amount])
-      
+
+      options[:order] = self.href
       destination = options[:destination]
-      amount = options[:amount]
-      
-      # extra parameters for labeling transactions 
-      description = options[:description]
-      appears_on_statement_as = options[:appears_on_statement_as]
       
       # should have a way here to disburse more funds to another account, but not required
-      credit = destination.credit(
-        :amount => amount, 
-        :order => self.href,
-        :appears_on_statement_as => appears_on_statement_as,
-        :description => description
-      )
+      credit = destination.credit(options)
         
       credit
     end

--- a/spec/balanced/resources/order_spec.rb
+++ b/spec/balanced/resources/order_spec.rb
@@ -53,23 +53,40 @@ describe Balanced::Order, :vcr, :marketplace => true do
     end
 
     it 'should debit buyer and pay merchant' do
+      # statement/description to test passthrough to debit/credit
+      @debit_description = 'Debit Description'
+      @debit_statement_message = 'Debit Statement Message'
+      @credit_description = 'Credit Description'
+      @credit_statement_message = 'Credit Statement Message'
+      
       debit = @order.debit_from(
           :source => @card,
-          :amount => 10000
+          :amount => 10000,
+          :appears_on_statement_as => @debit_statement_message,
+          :description => @debit_description
       )
 
       @order.reload
       @order.amount.should eq 10000
       @order.amount_escrowed.should eq 10000
+      
+      debit.description.should eq @debit_description
+      debit.appears_on_statement_as.should eq @debit_statement_message
 
-      @order.credit_to(
+      credit = @order.credit_to(
           :destination => @bank_account,
-          :amount => 8000
+          :amount => 8000,
+          :appears_on_statement_as => @credit_statement_message,
+          :description => @credit_description
       )
+      
       @order.reload
       @order.amount.should eq 10000
       @order.amount_escrowed.should eq 2000
       @order.debits.map { |d| d.href }.should include(debit.href)
+      
+      credit.description.should eq @credit_description
+      credit.appears_on_statement_as.should eq @credit_statement_message
     end
 
   end

--- a/spec/balanced/resources/order_spec.rb
+++ b/spec/balanced/resources/order_spec.rb
@@ -55,9 +55,9 @@ describe Balanced::Order, :vcr, :marketplace => true do
     it 'should debit buyer and pay merchant' do
       # statement/description to test passthrough to debit/credit
       @debit_description = 'Debit Description'
-      @debit_statement_message = 'Debit Statement Message'
+      @debit_statement_message = 'Debit Message'
       @credit_description = 'Credit Description'
-      @credit_statement_message = 'Credit Statement Message'
+      @credit_statement_message = 'Credit Message'
       
       debit = @order.debit_from(
           :source => @card,

--- a/spec/balanced/resources/order_spec.rb
+++ b/spec/balanced/resources/order_spec.rb
@@ -71,7 +71,7 @@ describe Balanced::Order, :vcr, :marketplace => true do
       @order.amount_escrowed.should eq 10000
       
       debit.description.should eq @debit_description
-      debit.appears_on_statement_as.should eq @debit_statement_message
+      debit.appears_on_statement_as.should eq "BAL*" << @debit_statement_message
 
       credit = @order.credit_to(
           :destination => @bank_account,


### PR DESCRIPTION
A simple addition to the Orders.(debit_from|credit_to) methods to enable custom :appears_on_statement text along with description (similar to @bcatherall commit #a50ce7e with meta)
