### PR TITLE
Faraday fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,7 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in balanced.gemspec
 
-gem "faraday"
-gem "faraday_middleware"
-gem "json"
+gemspec
 
 group :development do
   gem "yard"

--- a/balanced.gemspec
+++ b/balanced.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.summary       = %q{Sign up on https://balancedpayments.com/}
   gem.homepage      = "https://balancedpayments.com"
 
-  gem.add_dependency("faraday", '>= 0.8.6')
+  gem.add_dependency("faraday", '~> 0.8.6')
   gem.add_dependency("faraday_middleware", '~> 0.9.0')
 
   gem.files         = `git ls-files`.split($\)

--- a/lib/balanced/version.rb
+++ b/lib/balanced/version.rb
@@ -1,3 +1,3 @@
 module Balanced
-  VERSION = '0.8.1'
+  VERSION = '0.8.2'
 end


### PR DESCRIPTION
Changing faraday dependency to '~> 0.8.6', since 0.9.0 breaks.

Bumped version to 0.8.2.

Passed all tests locally.
